### PR TITLE
Remove double ports section

### DIFF
--- a/charts/freeipa/templates/service.yaml
+++ b/charts/freeipa/templates/service.yaml
@@ -65,4 +65,3 @@ spec:
     {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
-  ports:


### PR DESCRIPTION
`ports:` exists twice in the template and deployment fails with it.