### PR TITLE
fix: removed duplicate lifecycle argument from service template

### DIFF
--- a/charts/polymorphic-app/Chart.yaml
+++ b/charts/polymorphic-app/Chart.yaml
@@ -4,5 +4,5 @@ description: A Helm chart for deploying any custom applications, specifically po
 maintainers:
   - name: improwised
 type: application
-version: 1.2.7
+version: 1.2.8
 appVersion: 1.0.0

--- a/charts/polymorphic-app/templates/service.yaml
+++ b/charts/polymorphic-app/templates/service.yaml
@@ -117,11 +117,6 @@ spec:
           {{- if $.Values.serviceTemplate.volumeMounts }}
 {{ toYaml $.Values.serviceTemplate.volumeMounts | indent 10 }}
           {{- end }}
-          lifecycle:
-            preStop:
-              exec:
-                command: ["bash","-c","sleep 120"]
-
         {{- if or ($.Values.serviceTemplate.healthcheck.enabled) (.healthcheck.enabled) }}
           {{- if and (or (eq .healthcheck.type "httpGet") (eq $.Values.serviceTemplate.healthcheck.type "httpGet")) (or .healthcheck.path $.Values.serviceTemplate.healthcheck.path) }}
           livenessProbe:


### PR DESCRIPTION
## Fixes Issue
- Already there was a hard-coded `lifecycle` argument in service template which was being overwritten on the passed one.
## Changes proposed
- Remove the hard-coded `lifecycle` argument from service template.
## Check List
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.