### PR TITLE
feat: add multi-container support to apexkube helm chart (#145)

### DIFF
--- a/charts/apexkube/Chart.yaml
+++ b/charts/apexkube/Chart.yaml
@@ -5,4 +5,4 @@ maintainers:
   - name: improwised
 name: "apexkube"
 type: application
-version: 1.2.0
+version: 1.3.0

--- a/charts/apexkube/templates/service.yaml
+++ b/charts/apexkube/templates/service.yaml
@@ -134,7 +134,7 @@ spec:
           {{- if $.Values.serviceTemplate.volumeMounts }}
 {{ toYaml $.Values.serviceTemplate.volumeMounts | indent 10 }}
           {{- end }}
-        {{- if or ($.Values.serviceTemplate.healthcheck.enabled) (.healthcheck.enabled) }}
+        {{- if or ($.Values.serviceTemplate.healthcheck.enabled) (and .healthcheck .healthcheck.enabled) }}
         {{- if .healthcheck }}
 {{- $healthType := .healthcheck.type -}}
           {{- if and (eq $healthType "httpGet") (.healthcheck.path ) }}
@@ -195,6 +195,16 @@ spec:
           {{- end }}
 {{- end }}
         {{- end }}
+      {{- if or ($.Values.serviceTemplate.additionalContainers) (.additionalContainers) }}
+        {{- if .additionalContainers }}
+        {{- if $.Values.serviceTemplate.additionalContainers }}
+{{ toYaml $.Values.serviceTemplate.additionalContainers | indent 8 }}
+        {{- end }}
+{{ toYaml .additionalContainers | indent 8 }}
+        {{- else }}
+{{ toYaml $.Values.serviceTemplate.additionalContainers | indent 8 }}
+        {{- end }}
+      {{- end }}
       {{- with .dnsConfig | default $.Values.serviceTemplate.dnsConfig }}
       dnsConfig:
 {{ toYaml . | indent 8 }}

--- a/charts/apexkube/values.yaml
+++ b/charts/apexkube/values.yaml
@@ -45,6 +45,13 @@ serviceTemplate:
 
   initContainers: []
 
+  ## additionalContainers:
+  ##   - name: sidecar
+  ##     image: busybox:latest
+  ##     command: ['sh', '-c', 'echo hello']
+
+  additionalContainers: []
+
   lifecycleHooks: {}
 
   healthcheck:


### PR DESCRIPTION
## Description:
### Summary
Add additionalContainers support to the apexkube helm chart, enabling sidecar/multi-container pod deployments. This aligns with the existing implementation in the kube-oidc-proxy chart (see #140).
### Changes
#### charts/apexkube/values.yaml
- Added serviceTemplate.additionalContainers: [] with commented usage example
- Supports both serviceTemplate.additionalContainers (applied to all services) and per-service additionalContainers overrides
#### charts/apexkube/templates/service.yaml
- Added additionalContainers rendering block after the healthcheck section and before dnsConfig
- When both serviceTemplate.additionalContainers and per-service additionalContainers are defined, they are stacked together
- Bug fix: Fixed nil pointer error in healthcheck condition, changed .healthcheck.enabled to and .healthcheck .healthcheck.enabled to prevent template failure when .healthcheck is nil