### PR TITLE
fix(apexkube-agent): enable websocket and SPDY/3.1 upgrades in envoy

### DIFF
--- a/charts/apexkube-agent/Chart.yaml
+++ b/charts/apexkube-agent/Chart.yaml
@@ -4,5 +4,5 @@ description: A Helm chart for deploying the ApexKube agent with Envoy and WireGu
 maintainers:
   - name: improwised
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: "1.0.0"

--- a/charts/apexkube-agent/templates/envoy-config-cm.yaml
+++ b/charts/apexkube-agent/templates/envoy-config-cm.yaml
@@ -81,7 +81,13 @@ data:
                             domains: ["*"]
                             routes:
                               - match: { prefix: "/" }
-                                route: { cluster: service_backend }
+                                route:
+                                  cluster: service_backend
+                                  upgrade_configs:
+                                    - upgrade_type: "websocket"
+                                      enabled: true
+                                    - upgrade_type: "SPDY/3.1"
+                                      enabled: true
 
           clusters:
             - name: service_backend


### PR DESCRIPTION
Enables websocket and SPDY/3.1 connection upgrades in the apexkube-agent Envoy proxy route config by default. This fixes issues with pod exec and port-forwarding when accessing clusters via apexkube proxy.